### PR TITLE
Detect movement also in the negative direction

### DIFF
--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -336,7 +336,7 @@ void LD2450Component::handle_periodic_data_(uint8_t *buffer, int len) {
     if (ss != nullptr) {
       val = this->decode_speed_(buffer[start], buffer[start + 1]);
       ts = val;
-      if (val > 0) {
+      if (val) {
         is_moving = true;
         moving_target_count++;
       }


### PR DESCRIPTION
Movement should be registered if speed is non-zero, in both directions.

# What does this implement/fix?

Ensure that `moving_target_count` updates if there is object movement
also in the negative direction (towards the sensor).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
